### PR TITLE
fix: Prefer existing node bindings when trying to allocate tasks

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -316,13 +316,3 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 }
 
 func (alloc *Action) UnInitialize() {}
-
-func findNodeByName(nodeName string, nodeList []*api.NodeInfo) (*api.NodeInfo, error) {
-	for _, nodeInfo := range nodeList {
-		if nodeInfo.Name == nodeName {
-			return nodeInfo, nil
-		}
-	}
-
-	return nil, fmt.Errorf("no matching node found for name %s", nodeName)
-}


### PR DESCRIPTION
The theory here is that both Karpenter and Volcano use `nodeName` to nominate pods to specific nodes. However, since Volcano operates on a gang-scheduling basis, Volcano may also remove nominations from nodes when the gang cannot be fully scheduled. 

Since Volcano attempts to ["distribute" pods among nodes](https://github.com/predibase/volcano/blob/d44f1cd6dec69ab5555864ef9db0ac683afafb3f/pkg/scheduler/util/predicate_helper.go#L51-L50) and also parallelizes the predicate checks, the end result is that a particular pod may see different results from each Volcano scheduler cycle: in one cycle the pod may be nominated to node A, in the next to node B, in the next it may not get nominated at all because one of its peers got the nomination first.

Because of this, we theorize that Karpenter gets confused and thinks that a pod may be schedulable on a pod where it wouldn't actually fit.

I'm still thinking through the consequences (there are some potential gaps), but wanted to put up a draft PR for discussion.