### PR TITLE
int: Increase admission replicas

### DIFF
--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -73,7 +73,7 @@ metadata:
   name: {{ .Release.Name }}-admission
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: volcano-admission


### PR DESCRIPTION
Hoping that this gives us more resilience against transient auth issues with the K8s API. The nuclear option would be to ignore auth errors when validating incoming pods.