### PR TITLE
int: Disable plugins

### DIFF
--- a/installer/helm/chart/volcano/config/volcano-scheduler.conf
+++ b/installer/helm/chart/volcano/config/volcano-scheduler.conf
@@ -6,10 +6,10 @@ tiers:
     enablePreemptable: false
   - name: conformance
 - plugins:
-  - name: overcommit
-  - name: drf
-    enablePreemptable: false
-  - name: predicates
+  # - name: overcommit
+  # - name: drf
+  #   enablePreemptable: false
   - name: proportion
-  - name: nodeorder
+  - name: predicates
+  # - name: nodeorder
   - name: binpack


### PR DESCRIPTION
Disabled overcommit, drf, and nodeorder plugins to simplify volcano scheduling a bit.
Inspired by the older config we had here https://github.com/predibase/volcano/blob/predibase/installer/helm/chart/volcano/config/volcano-scheduler.conf